### PR TITLE
Change forwarding message to info logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ docker run --rm -it --net=host \
 subzerocloud/pg-amqp-bridge
 ```
 
+You can enable logging of the forwarded messages with the ```RUST_LOG=info``` environment variable.
+
 ## Sending messages
 **Note**: the bridge doesn't declare exchanges or queues, if they aren't previoulsy declared it will exit with an error.
 
@@ -62,12 +64,6 @@ NOTIFY pgchannel1, 'Task message';
 
 Since ```pgchannel1``` is bound to ```task_queue``` in BRIDGE_CHANNELS ```'Task message'``` will be sent to ```task_queue```.
 
-The following message is shown in the console :
-
-```bash
-Forwarding "Task message" from pg channel "pgchannel" to Queue "task_queue" with routing key "" 
-```
-
 #### Sending messages to a direct exchange
 
 You can specify a routing key with the format ```routing_key|message```:
@@ -77,12 +73,6 @@ NOTIFY pgchannel2, 'direct_key|Direct message';
 ```
 
 Since there is a ```pgchannel2:direct_exchange``` declared in BRIDGE_CHANNELS ```'Direct message'``` will be sent to ```direct_exchange``` with a routing key of ```direct_key```.
-
-This message is shown:
-
-```bash
-Forwarding "Direct message" from pg channel "pgchannel2" to Exchange "direct_exchange" with routing key "direct_key" 
-```
 
 #### Sending messages to a topic exchange
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate amqp;
 extern crate fallible_iterator;
 extern crate postgres;
+#[macro_use] extern crate log;
 
 use amqp::{Session, Basic, protocol, Channel, Table};
 use fallible_iterator::FallibleIterator;
@@ -106,8 +107,8 @@ fn spawn_listener_publisher(mut channel: Channel, pg_uri: String, binding: Bindi
       channel.basic_publish(exchange, key, true, false,
                             protocol::basic::BasicProperties{ content_type: Some("text".to_string()), ..Default::default()},
                             message.as_bytes().to_vec()).unwrap();
-      println!("Forwarding {:?} from pg channel {:?} to {:?} {:?} with routing key {:?} ",
-               message, binding.pg_channel, amqp_entity_type, binding.amqp_entity, routing_key);
+      info!("{:?} -> {:?} {:?} ( routing_key: {:?}, message: {:?} )",
+               binding.pg_channel, amqp_entity_type, binding.amqp_entity, routing_key, message);
     }
   })
 }


### PR DESCRIPTION
This is the new format shown:

```rust
"pgchannel2" -> Exchange "direct_logs" ( routing_key: "direct_key", message: "A mesage" )
"pgchannel1" -> Queue "hello" ( routing_key: "", message: "Another message" )
```

This is enabled passing the ```RUST_LOG=info``` env var.