### PR TITLE
Make NON-PERSISTENT the default delivery_mode/Add PostgreSQL connection retrying

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configuration is done through environment variables:
 - **POSTGRESQL_URI**: e.g. `postgresql://username:password@domain.tld:port/database`
 - **AMQP_URI**: e.g. `amqp://rabbitmq//`
 - **BRIDGE_CHANNELS**: e.g. `pgchannel1:task_queue,pgchannel2:direct_exchange,pgchannel3:topic_exchange`
-- **DELIVERY_MODE**: e.g. `PERSISTENT`, `NON-PERSISTENT`
+- **DELIVERY_MODE**: can be `PERSISTENT` or `NON-PERSISTENT`, default is `NON-PERSISTENT`
 
 **Note:** It's recommended to always use the same name for postgresql channel and exchange/queue in `BRIDGE_CHANNELS`, for example
 `app_events:app_events,table_changes:tables_changes`
@@ -38,7 +38,6 @@ mv pg-amqp-bridge /usr/local/bin
 POSTGRESQL_URI="postgres://postgres@localhost" \
 AMQP_URI="amqp://localhost//" \
 BRIDGE_CHANNELS="pgchannel1:task_queue,pgchannel2:direct_exchange,pgchannel3:topic_exchange" \
-DELIVERY_MODE="NON-PERSISTENT" \
 pg-amqp-bridge
 ```
 
@@ -49,7 +48,6 @@ docker run --rm -it --net=host \
 -e POSTGRESQL_URI="postgres://postgres@localhost" \
 -e AMQP_URI="amqp://localhost//" \
 -e BRIDGE_CHANNELS="pgchannel1:task_queue,pgchannel2:direct_exchange,pgchannel3:topic_exchange" \
--e DELIVERY_MODE="NON-PERSISTENT" \
 subzerocloud/pg-amqp-bridge
 ```
 
@@ -148,7 +146,6 @@ curl https://sh.rustup.rs -sSf | sh
 POSTGRESQL_URI="postgres://postgres@localhost" \
 AMQP_URI="amqp://localhost//" \
 BRIDGE_CHANNELS="pgchannel1:task_queue,pgchannel2:direct_exchange,pgchannel3:topic_exchange" \
-DELIVERY_MODE="NON-PERSISTENT" \
 cargo run
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Anyone and everyone is welcome to contribute.
 * [Slack](https://slack.subzero.cloud/) — Watch announcements, share ideas and feedback
 * [GitHub Issues](https://github.com/subzerocloud/pg-amqp-bridge/issues) — Check open issues, send feature requests
 
+## Author
+
+[@steve-chavez](https://github.com/steve-chavez)
+
 ## Credits
 
 Inspired by [@FGRibreau](https://github.com/FGRibreau/postgresql-to-amqp)'s work

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ struct Config {
   postgresql_uri: String,
   amqp_uri: String,
   bridge_channels: String,
-  delivery_mode: String,
+  delivery_mode: u8,
 }
 
 impl Config {
@@ -18,7 +18,13 @@ impl Config {
       postgresql_uri: env::var("POSTGRESQL_URI").expect("POSTGRESQL_URI environment variable must be defined"),
       amqp_uri: env::var("AMQP_URI").expect("AMQP_URI environment variable must be defined"),
       bridge_channels: env::var("BRIDGE_CHANNELS").expect("BRIDGE_CHANNELS environment variable must be defined"),
-      delivery_mode: env::var("DELIVERY_MODE").expect("DELIVERY_MODE environment variable must be defined"),
+      delivery_mode:
+        match env::var("DELIVERY_MODE").ok().as_ref().map(String::as_ref){
+          None => 1,
+          Some("NON-PERSISTENT") => 1,
+          Some("PERSISTENT") => 2,
+          Some(_) => panic!("DELIVERY_MODE environment variable can only be PERSISTENT or NON-PERSISTENT")
+        }
     }
   }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -231,7 +231,6 @@ fn main() {
                                 TEST_2_PG_CHANNEL, TEST_2_EXCHANGE,
                                 TEST_3_PG_CHANNEL, TEST_3_EXCHANGE);
 
-  let delivery_mode: &str = "PERSISTENT";
   setup();
   add_test(&mut tests, "publishing_to_queue_works".to_string(), publishing_to_queue_works);
   add_test(&mut tests, "publishing_to_direct_exchange_works".to_string(), publishing_to_direct_exchange_works);
@@ -239,8 +238,7 @@ fn main() {
   thread::spawn(move ||
     Bridge::new().start(&TEST_AMQP_URI.to_string(),
                         &TEST_PG_URI.to_string(),
-                        &bridge_channels,
-                        &delivery_mode)
+                        &bridge_channels, &(1 as u8))
   );
   thread::sleep(Duration::from_secs(2));
   test::test_main(&args, tests);


### PR DESCRIPTION
This makes the DELIVERY_MODE env var introduced in #8 optional, it defaults to NON-PERSISTENT.