### PR TITLE
Dockerfile Rework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,12 @@
-FROM debian:jessie
+FROM rust:slim AS builder
 
-ARG VERSION="0.0.0"
+WORKDIR /usr/src/pg-amqp-bridge
+COPY . .
+RUN cargo install --path .
 
-ENV POSTGRESQL_URI="postgres://postgres@postgresql"
-ENV AMQP_URI="amqp://rabbitmq//"
-ENV BRIDGE_CHANNELS="events:amq.topic"
 
-RUN DEBIAN_FRONTEND="noninteractive" && BUILD_DEPS="curl libssl-dev xz-utils" && \
-    apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends $BUILD_DEPS openssl ca-certificates dnsutils && \
-    cd /tmp && \
-    curl -SLO https://github.com/subzerocloud/pg-amqp-bridge/releases/download/${VERSION}/pg-amqp-bridge-${VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
-    tar zxf pg-amqp-bridge-${VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
-    mv pg-amqp-bridge /usr/local/bin/pg-amqp-bridge && \
-    cd / && \
-    apt-get -qq purge --auto-remove -y $BUILD_DEPS && \
-    apt-get -qq clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM debian:buster-slim
 
-CMD exec pg-amqp-bridge
+COPY --from=builder /usr/local/cargo/bin/pg-amqp-bridge /usr/local/bin/pg-amqp-bridge
+
+CMD ["pg-amqp-bridge"]


### PR DESCRIPTION
It now builds the binary itself.
I removed the default environment variables so that forgetting to set them manually results in easy to find errors. I like this approach more, as otherwise one could spend some time figuring out that an incorrect connection string is used, but this can be reverted, if desired.